### PR TITLE
implement smart/insensitive/sensitive case matching

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -9,6 +9,11 @@ use crate::PrinterType;
         .args(&["printer", "only", "json", "path_printer"])
         .multiple(false)
 ))]
+#[command(group(
+    clap::ArgGroup::new("case_group")
+        .args(&["ignore_case", "case_sensitive"])
+        .multiple(false)
+))]
 pub struct Args {
     pub pattern: String,
     pub path: Option<String>,
@@ -37,6 +42,14 @@ pub struct Args {
     /// Show a pruned JSON tree leading to the match
     #[clap(short, long)]
     pub json: bool,
+
+    /// Ignore case when matching. Default is smart-case.
+    #[clap(short = 'i', long = "ignore-case")]
+    pub ignore_case: bool,
+
+    /// Make matching case-sensitive. Default is smart-case.
+    #[clap(short = 'I', long = "case-sensitive")]
+    pub case_sensitive: bool,
 
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,10 @@ use std::process::exit;
 use args::Args;
 use clap::ValueEnum;
 use clap::Parser;
-use matcher::matcher::match_pattern;
+use matcher::matcher::match_pattern_with_case;
 use pattern::parser;
 use pattern::pattern::Pattern;
+use utils::string_utils::CaseSensitivity;
 
 mod args;
 pub mod matcher {
@@ -43,13 +44,19 @@ enum PrinterType {
     Only,
 }
 
-fn process_complete_json(content: &str, printer: &PrinterType, context: usize, pattern: &Pattern) {
+fn process_complete_json(
+    content: &str,
+    printer: &PrinterType,
+    context: usize,
+    pattern: &Pattern,
+    case_sensitivity: CaseSensitivity,
+) {
     let json = serde_json::from_str::<serde_json::Value>(content).unwrap_or_else(|_| {
         eprintln!("Invalid JSON");
         exit(3);
     });
 
-    let matches = match_pattern(&json, pattern);
+    let matches = match_pattern_with_case(&json, pattern, case_sensitivity);
 
     match printer {
         PrinterType::Path => {
@@ -64,7 +71,13 @@ fn process_complete_json(content: &str, printer: &PrinterType, context: usize, p
     }
 }
 
-fn process_file(path: &str, printer: PrinterType, context: usize, pattern: &Pattern) {
+fn process_file(
+    path: &str,
+    printer: PrinterType,
+    context: usize,
+    pattern: &Pattern,
+    case_sensitivity: CaseSensitivity,
+) {
     let mut content = String::new();
     let file = std::fs::File::open(path).unwrap_or_else(|_| {
         eprintln!("{}: No such file or directory", path);
@@ -73,10 +86,15 @@ fn process_file(path: &str, printer: PrinterType, context: usize, pattern: &Patt
     let mut reader = std::io::BufReader::new(file);
     reader.read_to_string(&mut content).unwrap();
 
-    process_complete_json(&content, &printer, context, pattern);
+    process_complete_json(&content, &printer, context, pattern, case_sensitivity);
 }
 
-fn stream_process(printer: PrinterType, context: usize, pattern: &Pattern) {
+fn stream_process(
+    printer: PrinterType,
+    context: usize,
+    pattern: &Pattern,
+    case_sensitivity: CaseSensitivity,
+) {
     let stdin = std::io::stdin();
     let mut buffer = String::new();
 
@@ -108,7 +126,7 @@ fn stream_process(printer: PrinterType, context: usize, pattern: &Pattern) {
 
             if depth == 0 {
                 buffer.push_str(&line[0..=i]);
-                process_complete_json(&buffer, &printer, context, pattern);
+                process_complete_json(&buffer, &printer, context, pattern, case_sensitivity);
                 buffer.clear();
                 start = None;
                 line = &line[i + 1..];
@@ -135,12 +153,25 @@ fn main() {
 
     let context = args.context.unwrap_or(0);
     let printer = get_printer(&args);
+    let case_sensitivity = resolve_case_sensitivity(&args, &args.pattern);
 
     if let Some(path) = args.path {
-        process_file(&path, printer, context, &pattern);
+        process_file(&path, printer, context, &pattern, case_sensitivity);
     } else {
-        stream_process(printer, context, &pattern);
+        stream_process(printer, context, &pattern, case_sensitivity);
     };
+}
+
+fn resolve_case_sensitivity(args: &Args, pattern: &str) -> CaseSensitivity {
+    if args.ignore_case {
+        CaseSensitivity::Insensitive
+    } else if args.case_sensitive {
+        CaseSensitivity::Sensitive
+    } else if pattern.chars().any(char::is_uppercase) {
+        CaseSensitivity::Sensitive
+    } else {
+        CaseSensitivity::Insensitive
+    }
 }
 
 // Requires that the printer flags are part of the same Clap::ArgGroup

--- a/src/matcher/matcher.rs
+++ b/src/matcher/matcher.rs
@@ -2,18 +2,18 @@ use serde_json::Value;
 
 use crate::{
     pattern::{pattern::Pattern, pattern_node::PatternNode},
-    utils::string_utils::wildcard_match,
+    utils::string_utils::{wildcard_match_with_case, CaseSensitivity},
 };
 
 use super::match_node::MatchNode;
 
 
-fn match_value(json: &Value, matching_value: &str) -> bool {
+fn match_value(json: &Value, matching_value: &str, case_sensitivity: CaseSensitivity) -> bool {
     match json {
-        Value::Null => wildcard_match("null", matching_value),
-        Value::Bool(b) => wildcard_match(&bool::to_string(b), matching_value),
-        Value::Number(n) => wildcard_match(n.as_str(), matching_value),
-        Value::String(s) => wildcard_match(s, matching_value),
+        Value::Null => wildcard_match_with_case("null", matching_value, case_sensitivity),
+        Value::Bool(b) => wildcard_match_with_case(&bool::to_string(b), matching_value, case_sensitivity),
+        Value::Number(n) => wildcard_match_with_case(n.as_str(), matching_value, case_sensitivity),
+        Value::String(s) => wildcard_match_with_case(s, matching_value, case_sensitivity),
         _ => false, // TODO also match objects and arrays?
     }
 }
@@ -30,6 +30,7 @@ fn match_internal(
     path: Vec<MatchNode>,
     or: bool,
     start_head: bool,
+    case_sensitivity: CaseSensitivity,
 ) -> Vec<Vec<MatchNode>> {
     let mut result: Vec<Vec<MatchNode>> = Vec::new();
 
@@ -39,7 +40,7 @@ fn match_internal(
     let extend_start_head = |result: &mut Vec<Vec<MatchNode>>, v: &Value, match_node: MatchNode| {
         let mut next_path = path.clone();
         next_path.push(match_node);
-        let head_matches = match_internal(v, matching_path, matching_val, next_path, or, true);
+        let head_matches = match_internal(v, matching_path, matching_val, next_path, or, true, case_sensitivity);
         result.extend(head_matches);
     };
 
@@ -50,7 +51,7 @@ fn match_internal(
         let next_nodes = &matching_path[1..];
         let mut next_path = path.clone();
         next_path.push(match_node);
-        let matches = match_internal(v, next_nodes, matching_val, next_path, or, false);
+        let matches = match_internal(v, next_nodes, matching_val, next_path, or, false, case_sensitivity);
         result.extend(matches);
     };
 
@@ -60,7 +61,7 @@ fn match_internal(
         |result: &mut Vec<Vec<MatchNode>>, v: &Value, match_node: MatchNode| {
             let mut next_path = path.clone();
             next_path.push(match_node);
-            let matches = match_internal(v, matching_path, matching_val, next_path, or, false);
+            let matches = match_internal(v, matching_path, matching_val, next_path, or, false, case_sensitivity);
             result.extend(matches);
         };
 
@@ -68,7 +69,7 @@ fn match_internal(
     // matched, and both the start and the match head extended, or the matching path is empty, in
     // which case only values are checked, and the start head extended.
     if matching_path.is_empty() {
-        if or || matching_val.map(|m| match_value(json, m)).unwrap_or(true) {
+        if or || matching_val.map(|m| match_value(json, m, case_sensitivity)).unwrap_or(true) {
             result.push(path.clone());
         }
         if start_head {
@@ -94,6 +95,7 @@ fn match_internal(
                 path.clone(),
                 or,
                 start_head,
+                case_sensitivity,
             ));
         }
 
@@ -119,7 +121,7 @@ fn match_internal(
             Value::Object(map) => {
                 for (k, v) in map.iter() {
                     if let PatternNode::Key(matching_key) = current_node {
-                        if wildcard_match(k, matching_key) {
+                        if wildcard_match_with_case(k, matching_key, case_sensitivity) {
                             let node = MatchNode::new_key(k.to_string(), true);
                             extend_match(&mut result, v, node);
                         }
@@ -134,7 +136,7 @@ fn match_internal(
                 }
             }
             _ => {
-                if or && matching_val.map(|m| match_value(json, m)).unwrap_or(false) {
+                if or && matching_val.map(|m| match_value(json, m, case_sensitivity)).unwrap_or(false) {
                     result.push(path);
                 }
             }
@@ -144,6 +146,14 @@ fn match_internal(
 }
 
 pub fn match_pattern(json: &Value, pattern: &Pattern) -> Vec<Vec<MatchNode>> {
+    match_pattern_with_case(json, pattern, CaseSensitivity::Sensitive)
+}
+
+pub fn match_pattern_with_case(
+    json: &Value,
+    pattern: &Pattern,
+    case_sensitivity: CaseSensitivity,
+) -> Vec<Vec<MatchNode>> {
     let mut matches = match_internal(
         json,
         &pattern.path,
@@ -151,6 +161,7 @@ pub fn match_pattern(json: &Value, pattern: &Pattern) -> Vec<Vec<MatchNode>> {
         vec![],
         pattern.or,
         !pattern.start_at_root,
+        case_sensitivity,
     );
     matches.dedup();
     matches
@@ -160,7 +171,30 @@ pub fn match_pattern(json: &Value, pattern: &Pattern) -> Vec<Vec<MatchNode>> {
 pub mod tests {
     use serde_json::json;
 
-    use crate::{matcher::{match_node::MatchNode, matcher::match_pattern}, pattern::parser};
+    use crate::{matcher::{match_node::MatchNode, matcher::{match_pattern, match_pattern_with_case}}, pattern::parser, utils::string_utils::CaseSensitivity};
+
+    #[test]
+    fn test_smart_case_matches_lowercase_pattern_case_insensitively() {
+        let pattern = parser::parse(".name").unwrap();
+        let json = json!({ "Name": "Alice" });
+
+        let result = match_pattern_with_case(&json, &pattern, CaseSensitivity::Smart);
+
+        assert_eq!(
+            result,
+            vec![vec![MatchNode::new_key("Name".to_string(), true)]]
+        );
+    }
+
+    #[test]
+    fn test_smart_case_keeps_mixed_case_pattern_case_sensitive() {
+        let pattern = parser::parse(".Name").unwrap();
+        let json = json!({ "name": "Alice" });
+
+        let result = match_pattern_with_case(&json, &pattern, CaseSensitivity::Smart);
+
+        assert!(result.is_empty());
+    }
 
     #[test]
     fn test_complete_path() {

--- a/src/utils/string_utils.rs
+++ b/src/utils/string_utils.rs
@@ -1,12 +1,41 @@
 use std::{iter::Peekable, str::Chars};
 
-pub fn wildcard_match_internal(mut haystack: Chars, mut needle: Peekable<Chars>) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaseSensitivity {
+    Smart,
+    Sensitive,
+    Insensitive,
+}
+
+impl CaseSensitivity {
+    pub fn should_ignore_case(self, pattern: &str) -> bool {
+        match self {
+            Self::Insensitive => true,
+            Self::Sensitive => false,
+            Self::Smart => !pattern.chars().any(char::is_uppercase),
+        }
+    }
+}
+
+fn chars_match(left: char, right: char, ignore_case: bool) -> bool {
+    if ignore_case {
+        left.to_lowercase().eq(right.to_lowercase())
+    } else {
+        left == right
+    }
+}
+
+fn wildcard_match_internal(
+    mut haystack: Chars,
+    mut needle: Peekable<Chars>,
+    ignore_case: bool,
+) -> bool {
     loop {
         match needle.peek() {
             Some('*') => {
                 let mut next_haystack = haystack.clone();
                 let c = next_haystack.next();
-                if c.is_some() && wildcard_match_internal(next_haystack, needle.clone()) {
+                if c.is_some() && wildcard_match_internal(next_haystack, needle.clone(), ignore_case) {
                     return true;
                 }
                 needle.next();
@@ -16,7 +45,8 @@ pub fn wildcard_match_internal(mut haystack: Chars, mut needle: Peekable<Chars>)
                 haystack.next();
             }
             Some(c) => {
-                if Some(*c) == haystack.next() {
+                let next = haystack.next();
+                if next.map(|value| chars_match(value, *c, ignore_case)).unwrap_or(false) {
                     needle.next();
                 } else {
                     return false;
@@ -30,9 +60,18 @@ pub fn wildcard_match_internal(mut haystack: Chars, mut needle: Peekable<Chars>)
 }
 
 pub fn wildcard_match(haystack: &str, needle: &str) -> bool {
+    wildcard_match_with_case(haystack, needle, CaseSensitivity::Sensitive)
+}
+
+pub fn wildcard_match_with_case(
+    haystack: &str,
+    needle: &str,
+    case_sensitivity: CaseSensitivity,
+) -> bool {
+    let ignore_case = case_sensitivity.should_ignore_case(needle);
     let haystack_chars = haystack.chars();
     let needle_chars = needle.chars().peekable();
-    wildcard_match_internal(haystack_chars, needle_chars)
+    wildcard_match_internal(haystack_chars, needle_chars, ignore_case)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
this introduces 2 new CLI flags:

- `-i` for case insensitive and
- `-I` for case sensitive pattern matching, leaving
- smart-case matching the default.

note, this is made with the help of `MAI-Code-1-Flash` LLM model.