### PR TITLE
implement raw output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you want to make suggestions, discussion is welcomed in the issues
 - [Usage](#Usage)
   - [Query language](#Query-language)
   - [Flags](#Flags)
+    - [Displaying only the match](#displaying-only-the-match)
     - [Displaying JSON instead of the path](#Displaying-JSON-instead-of-the-path)
     - [Context](#Context)
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -38,5 +38,9 @@ pub struct Args {
     #[clap(short, long)]
     pub json: bool,
 
+    /// Output scalar values as raw text when possible (number, boolean, single line string).
+    /// Works with the "path" and "only" printers.
+    #[clap(short = 'r', long = "raw")]
+    pub raw: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ pub mod utils {
 
 pub mod printers {
     pub mod json_printer;
+    pub mod output;
     pub mod path_printer;
     pub mod only_printer;
 
@@ -43,7 +44,7 @@ enum PrinterType {
     Only,
 }
 
-fn process_complete_json(content: &str, printer: &PrinterType, context: usize, pattern: &Pattern) {
+fn process_complete_json(content: &str, printer: &PrinterType, context: usize, raw: bool, pattern: &Pattern) {
     let json = serde_json::from_str::<serde_json::Value>(content).unwrap_or_else(|_| {
         eprintln!("Invalid JSON");
         exit(3);
@@ -53,18 +54,18 @@ fn process_complete_json(content: &str, printer: &PrinterType, context: usize, p
 
     match printer {
         PrinterType::Path => {
-            printers::path_printer::print(json, matches, context, std::io::stdout())
+            printers::path_printer::print(json, matches, context, raw, std::io::stdout())
         }
         PrinterType::Json => {
             printers::json_printer::print(json, matches, context, &mut std::io::stdout())
         }
         PrinterType::Only => {
-            printers::only_printer::print(json, matches, context, std::io::stdout())
+            printers::only_printer::print(json, matches, context, raw, std::io::stdout())
         }
     }
 }
 
-fn process_file(path: &str, printer: PrinterType, context: usize, pattern: &Pattern) {
+fn process_file(path: &str, printer: PrinterType, context: usize, raw: bool, pattern: &Pattern) {
     let mut content = String::new();
     let file = std::fs::File::open(path).unwrap_or_else(|_| {
         eprintln!("{}: No such file or directory", path);
@@ -73,10 +74,10 @@ fn process_file(path: &str, printer: PrinterType, context: usize, pattern: &Patt
     let mut reader = std::io::BufReader::new(file);
     reader.read_to_string(&mut content).unwrap();
 
-    process_complete_json(&content, &printer, context, pattern);
+    process_complete_json(&content, &printer, context, raw, pattern);
 }
 
-fn stream_process(printer: PrinterType, context: usize, pattern: &Pattern) {
+fn stream_process(printer: PrinterType, context: usize, raw: bool, pattern: &Pattern) {
     let stdin = std::io::stdin();
     let mut buffer = String::new();
 
@@ -108,7 +109,7 @@ fn stream_process(printer: PrinterType, context: usize, pattern: &Pattern) {
 
             if depth == 0 {
                 buffer.push_str(&line[0..=i]);
-                process_complete_json(&buffer, &printer, context, pattern);
+                process_complete_json(&buffer, &printer, context, raw, pattern);
                 buffer.clear();
                 start = None;
                 line = &line[i + 1..];
@@ -120,8 +121,22 @@ fn stream_process(printer: PrinterType, context: usize, pattern: &Pattern) {
     }
 }
 
+fn validate_args(args: &Args) -> Result<(), String> {
+    let printer = get_printer(args);
+    if args.raw && printer == PrinterType::Json {
+        return Err("-r/--raw cannot be used with the json printer".into());
+    }
+
+    Ok(())
+}
+
 fn main() {
     let args = Args::parse();
+
+    if let Err(err) = validate_args(&args) {
+        eprintln!("{}", err);
+        exit(3);
+    }
 
     // Parse pattern
     let pattern = parser::parse(&args.pattern);
@@ -135,11 +150,12 @@ fn main() {
 
     let context = args.context.unwrap_or(0);
     let printer = get_printer(&args);
+    let raw = args.raw;
 
     if let Some(path) = args.path {
-        process_file(&path, printer, context, &pattern);
+        process_file(&path, printer, context, raw, &pattern);
     } else {
-        stream_process(printer, context, &pattern);
+        stream_process(printer, context, raw, &pattern);
     };
 }
 

--- a/src/printers/only_printer.rs
+++ b/src/printers/only_printer.rs
@@ -4,8 +4,9 @@ use serde_json::Value;
 
 use crate::matcher::match_node::MatchNode;
 
+use super::output::format_value;
 
-pub fn print<W: Write>(value: Value, matches: Vec<Vec<MatchNode>>, context: usize, mut writer: W) {
+pub fn print<W: Write>(value: Value, matches: Vec<Vec<MatchNode>>, context: usize, raw: bool, mut writer: W) {
     for path in matches {
         let mut value_to_print = &value;
         let mut path = path.clone();
@@ -23,7 +24,8 @@ pub fn print<W: Write>(value: Value, matches: Vec<Vec<MatchNode>>, context: usiz
                 },
             }
         }
-        write!(writer, "{}", value_to_print).unwrap();
+        let formatted_value = format_value(value_to_print, raw);
+        write!(writer, "{}", formatted_value).unwrap();
         writeln!(writer).unwrap();
     }
 }
@@ -57,7 +59,7 @@ mod tests {
         ];
 
         let mut output = Vec::new();
-        super::print(value, matches, 0, &mut output);
+        super::print(value, matches, 0, false, &mut output);
         let output = String::from_utf8(output).unwrap();
 
         assert_eq!(output, "0\n{\"patatas\":\"felices\"}\n")

--- a/src/printers/output.rs
+++ b/src/printers/output.rs
@@ -1,0 +1,17 @@
+use serde_json::Value;
+
+pub fn format_value(value: &Value, raw: bool) -> String {
+    if raw {
+        match value {
+            Value::String(s) if !s.contains('\n') => return s.clone(),
+            Value::String(s) if s.ends_with('\n') && s.matches('\n').count() == 1 => {
+                return s.trim_end_matches('\n').to_string()
+            }
+            Value::Number(n) => return n.to_string(),
+            Value::Bool(b) => return b.to_string(),
+            _ => {}
+        }
+    }
+
+    value.to_string()
+}

--- a/src/printers/path_printer.rs
+++ b/src/printers/path_printer.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use crate::matcher::match_node::MatchNode;
 
-pub fn print<W: Write>(value: Value, matches: Vec<Vec<MatchNode>>, context: usize, mut writer: W) {
+use super::output::format_value;
+
+pub fn print<W: Write>(value: Value, matches: Vec<Vec<MatchNode>>, context: usize, raw: bool, mut writer: W) {
     for path in matches {
         let mut value_to_print = &value;
         let mut path = path.clone();
@@ -24,7 +26,8 @@ pub fn print<W: Write>(value: Value, matches: Vec<Vec<MatchNode>>, context: usiz
                 },
             }
         }
-        write!(writer, ": {}", value_to_print).unwrap();
+        let formatted_value = format_value(value_to_print, raw);
+        write!(writer, ": {}", formatted_value).unwrap();
         writeln!(writer).unwrap();
     }
 }
@@ -58,7 +61,7 @@ mod test {
         ];
 
         let mut output = Vec::new();
-        super::print(value, matches, 0, &mut output);
+        super::print(value, matches, 0, false, &mut output);
         let output = String::from_utf8(output).unwrap();
 
         assert_eq!(output, ".a[0].c: 0\n.a[3][0]: {\"patatas\":\"felices\"}\n")

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -148,6 +148,51 @@ fn flags_only() {
 }
 
 #[test]
+fn flags_raw_only() {
+    let mut cmd = Command::cargo_bin("jgrep").unwrap();
+    cmd.arg(".name");
+    cmd.arg("-r");
+    cmd.arg("-o");
+    cmd.write_stdin(indoc!(
+        r#"
+        {"name":"Jane","verified":true}
+    "#
+    ));
+
+    cmd.assert().code(0).stdout("Jane\n");
+}
+
+#[test]
+fn flags_raw_path() {
+    let mut cmd = Command::cargo_bin("jgrep").unwrap();
+    cmd.arg(".name");
+    cmd.arg("-r");
+    cmd.arg("-P");
+    cmd.write_stdin(indoc!(
+        r#"
+        {"name":"Jane","verified":true}
+    "#
+    ));
+
+    cmd.assert().code(0).stdout(".name: Jane\n");
+}
+
+#[test]
+fn flags_raw_with_json_printer_fails() {
+    let mut cmd = Command::cargo_bin("jgrep").unwrap();
+    cmd.arg(".name");
+    cmd.arg("-r");
+    cmd.arg("-j");
+    cmd.write_stdin(indoc!(
+        r#"
+        {"name":"Jane","verified":true}
+    "#
+    ));
+
+    cmd.assert().code(3);
+}
+
+#[test]
 fn context() {
     let out = ".items[1].meta.author: {\"name\":\"Jane\",\"verified\":true}\n";
 


### PR DESCRIPTION
i'm not sure how much does it fit to jgrep's philisophy, since this new `--raw` mode may produce eg. both json-looking unquoted strings and real json-encoded objects, so not unambiguous if the user does not know what may be expected as output. but useful if one knows the return value is always eg. a single-line string.

Note, this is made by the help of `MAI-Code-1-Flash` LLM.
